### PR TITLE
feat: main layout — three-pane UI, Cast & Locations phase, Library navigator

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,15 @@
+# Contributors
+
+Thank you to everyone who has contributed to DrawThingsStoryboard!
+
+## Project Author
+
+- **Ingo Hoffmann** ([@SuperEugen](https://github.com/SuperEugen)) — creator and lead developer
+
+## AI Assistance
+
+- **Claude** (Anthropic) — architecture design, Swift/SwiftUI code generation, PR writing, and pair programming throughout the project
+
+---
+
+*Contributions of any kind are welcome — ideas, bug reports, code, and feedback.*

--- a/DrawThingsStoryboard/App/AppSection.swift
+++ b/DrawThingsStoryboard/App/AppSection.swift
@@ -1,21 +1,36 @@
 import Foundation
 
-/// All top-level navigation sections of the app.
-/// Add a new case here when adding a new feature.
+/// Top-level navigation sections — one per production phase plus library access.
 enum AppSection: String, CaseIterable, Identifiable, Hashable {
-    case imageGeneration
+
+    // Production phases
+    case briefing
+    case casting
+    case writing
+    case production
+
+    // Library management
+    case library
 
     var id: String { rawValue }
 
     var title: String {
         switch self {
-        case .imageGeneration: return "Image Generation"
+        case .briefing:   return "Briefing"
+        case .casting:    return "Casting"
+        case .writing:    return "Writing"
+        case .production: return "Production"
+        case .library:    return "Library"
         }
     }
 
     var icon: String {
         switch self {
-        case .imageGeneration: return "wand.and.sparkles"
+        case .briefing:   return "doc.text"
+        case .casting:    return "person.2"
+        case .writing:    return "pencil.and.list.clipboard"
+        case .production: return "film.stack"
+        case .library:    return "photo.stack"
         }
     }
 }

--- a/DrawThingsStoryboard/App/ContentView.swift
+++ b/DrawThingsStoryboard/App/ContentView.swift
@@ -1,17 +1,23 @@
 import SwiftUI
 
-/// Root layout: NavigationSplitView with sidebar + detail.
+/// Root layout: three-pane NavigationSplitView.
+/// Left   = phase/section navigation (SidebarView)
+/// Center = item browser for the selected phase (ItemBrowserView)
+/// Right  = properties of the selected item (ItemDetailView)
 struct ContentView: View {
 
-    @State private var selectedSection: AppSection? = .imageGeneration
+    @State private var selectedSection: AppSection? = .briefing
+    @State private var selectedItemID: String? = nil
 
     var body: some View {
         NavigationSplitView {
             SidebarView(selectedSection: $selectedSection)
+        } content: {
+            ItemBrowserView(section: selectedSection, selectedItemID: $selectedItemID)
         } detail: {
-            DetailRouter(selectedSection: selectedSection)
+            ItemDetailView(section: selectedSection, itemID: selectedItemID)
         }
-        .frame(minWidth: 900, minHeight: 600)
+        .frame(minWidth: 1100, minHeight: 680)
     }
 }
 

--- a/DrawThingsStoryboard/App/ContentView.swift
+++ b/DrawThingsStoryboard/App/ContentView.swift
@@ -3,30 +3,45 @@ import SwiftUI
 /// Root layout: three-pane NavigationSplitView.
 /// Left   = phase/section navigation (SidebarView)
 /// Center = item browser for the selected phase (ItemBrowserView)
+///          — Library section uses its own full LibraryView instead
 /// Right  = properties of the selected item (ItemDetailView)
 struct ContentView: View {
 
-    @State private var selectedSection: AppSection? = .casting
+    @State private var selectedSection: AppSection?    = .casting
     @State private var selectedCastingItem: CastingItem? = nil
-    @State private var selectedItemID: String? = nil
+    @State private var selectedItemID: String?           = nil
 
     var body: some View {
-        NavigationSplitView {
-            SidebarView(selectedSection: $selectedSection)
-        } content: {
-            ItemBrowserView(
-                section: selectedSection,
-                selectedCastingItem: $selectedCastingItem,
-                selectedItemID: $selectedItemID
-            )
-        } detail: {
-            ItemDetailView(
-                section: selectedSection,
-                selectedCastingItem: $selectedCastingItem,
-                selectedItemID: selectedItemID
-            )
+        if selectedSection == .library {
+            // Library gets its own full-width layout with built-in navigator
+            NavigationSplitView {
+                SidebarView(selectedSection: $selectedSection)
+            } detail: {
+                LibraryView()
+            }
+            .frame(minWidth: 1100, minHeight: 680)
+        } else {
+            NavigationSplitView {
+                SidebarView(selectedSection: $selectedSection)
+            } content: {
+                ItemBrowserView(
+                    section: selectedSection,
+                    selectedCastingItem: $selectedCastingItem,
+                    selectedItemID: $selectedItemID
+                )
+            } detail: {
+                ItemDetailView(
+                    section: selectedSection,
+                    selectedCastingItem: $selectedCastingItem,
+                    selectedItemID: selectedItemID
+                )
+            }
+            .frame(minWidth: 1100, minHeight: 680)
+            .onChange(of: selectedSection) { _, _ in
+                selectedCastingItem = nil
+                selectedItemID = nil
+            }
         }
-        .frame(minWidth: 1100, minHeight: 680)
     }
 }
 

--- a/DrawThingsStoryboard/App/ContentView.swift
+++ b/DrawThingsStoryboard/App/ContentView.swift
@@ -6,16 +6,25 @@ import SwiftUI
 /// Right  = properties of the selected item (ItemDetailView)
 struct ContentView: View {
 
-    @State private var selectedSection: AppSection? = .briefing
+    @State private var selectedSection: AppSection? = .casting
+    @State private var selectedCastingItem: CastingItem? = nil
     @State private var selectedItemID: String? = nil
 
     var body: some View {
         NavigationSplitView {
             SidebarView(selectedSection: $selectedSection)
         } content: {
-            ItemBrowserView(section: selectedSection, selectedItemID: $selectedItemID)
+            ItemBrowserView(
+                section: selectedSection,
+                selectedCastingItem: $selectedCastingItem,
+                selectedItemID: $selectedItemID
+            )
         } detail: {
-            ItemDetailView(section: selectedSection, itemID: selectedItemID)
+            ItemDetailView(
+                section: selectedSection,
+                selectedCastingItem: $selectedCastingItem,
+                selectedItemID: selectedItemID
+            )
         }
         .frame(minWidth: 1100, minHeight: 680)
     }

--- a/DrawThingsStoryboard/App/DetailRouter.swift
+++ b/DrawThingsStoryboard/App/DetailRouter.swift
@@ -1,21 +1,9 @@
 import SwiftUI
 
-/// Routes the selected sidebar section to the correct feature view.
-/// Add new cases here as features are built.
+/// DetailRouter is superseded by the three-pane NavigationSplitView in ContentView.
+/// Kept as a stub to avoid Xcode "missing reference" issues until old ImageGenerationView
+/// scaffolding is cleaned up in a follow-up.
 struct DetailRouter: View {
-
     let selectedSection: AppSection?
-
-    var body: some View {
-        switch selectedSection {
-        case .imageGeneration:
-            ImageGenerationView()
-        case .none:
-            ContentUnavailableView(
-                "Nothing selected",
-                systemImage: "sidebar.left",
-                description: Text("Choose a section from the sidebar.")
-            )
-        }
-    }
+    var body: some View { EmptyView() }
 }

--- a/DrawThingsStoryboard/App/SidebarView.swift
+++ b/DrawThingsStoryboard/App/SidebarView.swift
@@ -6,11 +6,18 @@ struct SidebarView: View {
 
     var body: some View {
         List(selection: $selectedSection) {
-            Section("Generate") {
-                Label(AppSection.imageGeneration.title, systemImage: AppSection.imageGeneration.icon)
-                    .tag(AppSection.imageGeneration)
+
+            Section("Project") {
+                ForEach([AppSection.briefing, .casting, .writing, .production]) { section in
+                    Label(section.title, systemImage: section.icon)
+                        .tag(section)
+                }
             }
-            // New sections added here as features are built
+
+            Section("Assets") {
+                Label(AppSection.library.title, systemImage: AppSection.library.icon)
+                    .tag(AppSection.library)
+            }
         }
         .listStyle(.sidebar)
         .navigationTitle("DrawThingsStoryboard")
@@ -18,5 +25,5 @@ struct SidebarView: View {
 }
 
 #Preview {
-    SidebarView(selectedSection: .constant(.imageGeneration))
+    SidebarView(selectedSection: .constant(.briefing))
 }

--- a/DrawThingsStoryboard/Features/ItemBrowser/ItemBrowserView.swift
+++ b/DrawThingsStoryboard/Features/ItemBrowser/ItemBrowserView.swift
@@ -1,55 +1,39 @@
 import SwiftUI
 
-/// Center pane: header + scrollable item grid for the selected phase.
-/// Uses mock data — no real filesystem access yet.
+/// Center pane — adapts to the selected phase.
+/// Casting phase: two sub-sections (Cast + Locations) with independent +/- controls.
+/// Other phases: generic single-section grid.
 struct ItemBrowserView: View {
 
     let section: AppSection?
-    @Binding var selectedItemID: String?
+    @Binding var selectedCastingItem: CastingItem?
 
-    private let columns = [
-        GridItem(.adaptive(minimum: 140, maximum: 180), spacing: 12)
-    ]
+    // Generic phases
+    @Binding var selectedItemID: String?
 
     var body: some View {
         VStack(spacing: 0) {
-
-            // ── Header ──────────────────────────────────────────────
             BrowserHeaderView(section: section)
-
             Divider()
 
-            // ── Item Grid ────────────────────────────────────────────
-            if MockItems.items(for: section).isEmpty {
-                ContentUnavailableView(
-                    "No items yet",
-                    systemImage: section?.icon ?? "tray",
-                    description: Text("Items created in this phase will appear here.")
-                )
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            if section == .casting {
+                CastingBrowserView(selectedItem: $selectedCastingItem)
             } else {
-                ScrollView {
-                    LazyVGrid(columns: columns, spacing: 12) {
-                        ForEach(MockItems.items(for: section)) { item in
-                            ItemTileView(item: item, isSelected: selectedItemID == item.id)
-                                .onTapGesture { selectedItemID = item.id }
-                        }
-                    }
-                    .padding(16)
-                }
+                GenericBrowserView(section: section, selectedItemID: $selectedItemID)
             }
         }
         .background(Color(NSColor.windowBackgroundColor))
-        .onChange(of: section) { _, _ in selectedItemID = nil }
+        .onChange(of: section) { _, _ in
+            selectedCastingItem = nil
+            selectedItemID = nil
+        }
     }
 }
 
 // MARK: - Header
 
 private struct BrowserHeaderView: View {
-
     let section: AppSection?
-
     var body: some View {
         HStack(alignment: .firstTextBaseline, spacing: 8) {
             if let section {
@@ -59,9 +43,6 @@ private struct BrowserHeaderView: View {
                 Text(section.title)
                     .font(.title2.bold())
                 Spacer()
-                Text("\(MockItems.items(for: section).count) items")
-                    .font(.caption)
-                    .foregroundStyle(.tertiary)
             }
         }
         .padding(.horizontal, 16)
@@ -69,43 +50,229 @@ private struct BrowserHeaderView: View {
     }
 }
 
-// MARK: - Item Tile
+// MARK: - Casting browser (Cast + Locations split)
 
-private struct ItemTileView: View {
+struct CastingBrowserView: View {
 
-    let item: MockItem
+    @Binding var selectedItem: CastingItem?
+    @State private var characters: [CastingItem] = MockData.castingCharacters
+    @State private var locations: [CastingItem]  = MockData.castingLocations
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 0) {
+                CastingSubSectionView(
+                    title: "Cast",
+                    items: $characters,
+                    selectedItem: $selectedItem,
+                    itemType: .character
+                )
+                Divider().padding(.vertical, 4)
+                CastingSubSectionView(
+                    title: "Locations",
+                    items: $locations,
+                    selectedItem: $selectedItem,
+                    itemType: .location
+                )
+            }
+            .padding(.bottom, 16)
+        }
+    }
+}
+
+// MARK: - Sub-section (Cast or Locations)
+
+private struct CastingSubSectionView: View {
+
+    let title: String
+    @Binding var items: [CastingItem]
+    @Binding var selectedItem: CastingItem?
+    let itemType: CastingItemType
+
+    private let columns = [GridItem(.adaptive(minimum: 110, maximum: 150), spacing: 10)]
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Section header row
+            HStack {
+                Text(title)
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(.secondary)
+                Spacer()
+                // − button
+                Button {
+                    guard let sel = selectedItem,
+                          let idx = items.firstIndex(where: { $0.id == sel.id }) else { return }
+                    items.remove(at: idx)
+                    selectedItem = nil
+                } label: {
+                    Image(systemName: "minus")
+                        .frame(width: 22, height: 22)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.mini)
+                .disabled(selectedItem == nil || !items.contains(where: { $0.id == selectedItem?.id }))
+                // + button
+                Button {
+                    let newItem = CastingItem(
+                        id: UUID().uuidString,
+                        name: itemType == .character ? "New Character" : "New Location",
+                        description: "",
+                        type: itemType,
+                        status: .notYetGenerated,
+                        libraryLevel: .episode,
+                        variantCount: 0,
+                        approvedVariant: nil
+                    )
+                    items.append(newItem)
+                    selectedItem = newItem
+                } label: {
+                    Image(systemName: "plus")
+                        .frame(width: 22, height: 22)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.mini)
+            }
+            .padding(.horizontal, 14)
+            .padding(.top, 12)
+            .padding(.bottom, 6)
+
+            if items.isEmpty {
+                Text("No \(title.lowercased()) yet — tap + to add one.")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+                    .padding(.vertical, 20)
+            } else {
+                LazyVGrid(columns: columns, spacing: 10) {
+                    ForEach(items) { item in
+                        CastingTileView(
+                            item: item,
+                            isSelected: selectedItem?.id == item.id
+                        )
+                        .onTapGesture { selectedItem = item }
+                    }
+                }
+                .padding(.horizontal, 14)
+                .padding(.bottom, 8)
+            }
+        }
+    }
+}
+
+// MARK: - Tile
+
+private struct CastingTileView: View {
+
+    let item: CastingItem
     let isSelected: Bool
 
     var body: some View {
+        VStack(spacing: 5) {
+            ZStack(alignment: .bottomTrailing) {
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(tileColor.opacity(0.15))
+                    .overlay {
+                        Image(systemName: tileIcon)
+                            .font(.system(size: 28))
+                            .foregroundStyle(tileColor)
+                    }
+                    .frame(height: 80)
+
+                // Status dot
+                Circle()
+                    .fill(item.status.color)
+                    .frame(width: 8, height: 8)
+                    .padding(5)
+            }
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(isSelected ? Color.accentColor : Color.clear, lineWidth: 1.5)
+            )
+
+            Text(item.name)
+                .font(.caption)
+                .lineLimit(1)
+                .foregroundStyle(isSelected ? Color.accentColor : .primary)
+        }
+        .padding(5)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(isSelected ? Color.accentColor.opacity(0.07) : Color.clear)
+        )
+    }
+
+    private var tileColor: Color {
+        item.type == .character ? .blue : .teal
+    }
+
+    private var tileIcon: String {
+        item.type == .character ? "person.fill" : "map"
+    }
+}
+
+// MARK: - Generic browser (non-casting phases)
+
+private struct GenericBrowserView: View {
+
+    let section: AppSection?
+    @Binding var selectedItemID: String?
+    private let columns = [GridItem(.adaptive(minimum: 130, maximum: 170), spacing: 12)]
+
+    var body: some View {
+        let items = MockData.items(for: section)
+        if items.isEmpty {
+            ContentUnavailableView(
+                "No items yet",
+                systemImage: section?.icon ?? "tray",
+                description: Text("Items will appear here once created.")
+            )
+        } else {
+            ScrollView {
+                LazyVGrid(columns: columns, spacing: 12) {
+                    ForEach(items) { item in
+                        GenericTileView(item: item, isSelected: selectedItemID == item.id)
+                            .onTapGesture { selectedItemID = item.id }
+                    }
+                }
+                .padding(16)
+            }
+        }
+    }
+}
+
+private struct GenericTileView: View {
+    let item: MockItem
+    let isSelected: Bool
+    var body: some View {
         VStack(spacing: 6) {
             RoundedRectangle(cornerRadius: 10)
-                .fill(item.color.opacity(0.18))
+                .fill(item.color.opacity(0.15))
                 .overlay {
                     Image(systemName: item.icon)
-                        .font(.system(size: 36))
+                        .font(.system(size: 32))
                         .foregroundStyle(item.color)
                 }
-                .frame(height: 120)
+                .frame(height: 100)
                 .overlay(
                     RoundedRectangle(cornerRadius: 10)
-                        .stroke(isSelected ? Color.accentColor : Color.clear, lineWidth: 2)
+                        .stroke(isSelected ? Color.accentColor : Color.clear, lineWidth: 1.5)
                 )
-
             Text(item.name)
                 .font(.caption)
                 .lineLimit(2)
                 .multilineTextAlignment(.center)
-                .foregroundStyle(isSelected ? Color.accentColor : .primary)
         }
         .padding(6)
         .background(
             RoundedRectangle(cornerRadius: 12)
-                .fill(isSelected ? Color.accentColor.opacity(0.08) : Color.clear)
+                .fill(isSelected ? Color.accentColor.opacity(0.07) : Color.clear)
         )
     }
 }
 
 #Preview {
-    ItemBrowserView(section: .casting, selectedItemID: .constant(nil))
-        .frame(width: 500, height: 600)
+    @Previewable @State var sel: CastingItem? = nil
+    @Previewable @State var selID: String? = nil
+    ItemBrowserView(section: .casting, selectedCastingItem: $sel, selectedItemID: $selID)
+        .frame(width: 480, height: 600)
 }

--- a/DrawThingsStoryboard/Features/ItemBrowser/ItemBrowserView.swift
+++ b/DrawThingsStoryboard/Features/ItemBrowser/ItemBrowserView.swift
@@ -1,0 +1,111 @@
+import SwiftUI
+
+/// Center pane: header + scrollable item grid for the selected phase.
+/// Uses mock data — no real filesystem access yet.
+struct ItemBrowserView: View {
+
+    let section: AppSection?
+    @Binding var selectedItemID: String?
+
+    private let columns = [
+        GridItem(.adaptive(minimum: 140, maximum: 180), spacing: 12)
+    ]
+
+    var body: some View {
+        VStack(spacing: 0) {
+
+            // ── Header ──────────────────────────────────────────────
+            BrowserHeaderView(section: section)
+
+            Divider()
+
+            // ── Item Grid ────────────────────────────────────────────
+            if MockItems.items(for: section).isEmpty {
+                ContentUnavailableView(
+                    "No items yet",
+                    systemImage: section?.icon ?? "tray",
+                    description: Text("Items created in this phase will appear here.")
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                ScrollView {
+                    LazyVGrid(columns: columns, spacing: 12) {
+                        ForEach(MockItems.items(for: section)) { item in
+                            ItemTileView(item: item, isSelected: selectedItemID == item.id)
+                                .onTapGesture { selectedItemID = item.id }
+                        }
+                    }
+                    .padding(16)
+                }
+            }
+        }
+        .background(Color(NSColor.windowBackgroundColor))
+        .onChange(of: section) { _, _ in selectedItemID = nil }
+    }
+}
+
+// MARK: - Header
+
+private struct BrowserHeaderView: View {
+
+    let section: AppSection?
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            if let section {
+                Image(systemName: section.icon)
+                    .font(.title2)
+                    .foregroundStyle(.secondary)
+                Text(section.title)
+                    .font(.title2.bold())
+                Spacer()
+                Text("\(MockItems.items(for: section).count) items")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+}
+
+// MARK: - Item Tile
+
+private struct ItemTileView: View {
+
+    let item: MockItem
+    let isSelected: Bool
+
+    var body: some View {
+        VStack(spacing: 6) {
+            RoundedRectangle(cornerRadius: 10)
+                .fill(item.color.opacity(0.18))
+                .overlay {
+                    Image(systemName: item.icon)
+                        .font(.system(size: 36))
+                        .foregroundStyle(item.color)
+                }
+                .frame(height: 120)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10)
+                        .stroke(isSelected ? Color.accentColor : Color.clear, lineWidth: 2)
+                )
+
+            Text(item.name)
+                .font(.caption)
+                .lineLimit(2)
+                .multilineTextAlignment(.center)
+                .foregroundStyle(isSelected ? Color.accentColor : .primary)
+        }
+        .padding(6)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(isSelected ? Color.accentColor.opacity(0.08) : Color.clear)
+        )
+    }
+}
+
+#Preview {
+    ItemBrowserView(section: .casting, selectedItemID: .constant(nil))
+        .frame(width: 500, height: 600)
+}

--- a/DrawThingsStoryboard/Features/ItemBrowser/ItemDetailView.swift
+++ b/DrawThingsStoryboard/Features/ItemBrowser/ItemDetailView.swift
@@ -45,151 +45,15 @@ struct CastingItemDetailView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
-
-                // ── Type badge + thumbnail placeholder ───────────────
-                ZStack(alignment: .topLeading) {
-                    RoundedRectangle(cornerRadius: 10)
-                        .fill(thumbnailColor.opacity(0.12))
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 160)
-                        .overlay {
-                            Image(systemName: thumbnailIcon)
-                                .font(.system(size: 52))
-                                .foregroundStyle(thumbnailColor.opacity(0.6))
-                        }
-
-                    // Type label
-                    Text(typeLabel)
-                        .font(.caption.weight(.medium))
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 4)
-                        .background(.thinMaterial, in: Capsule())
-                        .foregroundStyle(.secondary)
-                        .padding(10)
-                }
-                .padding(.bottom, 16)
-
-                // ── Status ───────────────────────────────────────────
-                DetailSection(title: "Status") {
-                    VStack(spacing: 4) {
-                        ForEach(GenerationStatus.allCases) { s in
-                            HStack(spacing: 8) {
-                                Circle()
-                                    .fill(s.color)
-                                    .frame(width: 8, height: 8)
-                                Text(s.label)
-                                    .font(.callout)
-                                Spacer()
-                                if item.status == s {
-                                    Image(systemName: "checkmark")
-                                        .font(.caption.weight(.medium))
-                                        .foregroundStyle(.accentColor)
-                                }
-                            }
-                            .padding(.vertical, 5)
-                            .padding(.horizontal, 8)
-                            .background(
-                                RoundedRectangle(cornerRadius: 7)
-                                    .fill(item.status == s ? Color.accentColor.opacity(0.07) : Color.clear)
-                            )
-                            .contentShape(Rectangle())
-                            .onTapGesture { item.status = s }
-                        }
-                    }
-                }
-
+                thumbnailSection
+                statusSection
                 Divider().padding(.vertical, 8)
-
-                // ── Library level ────────────────────────────────────
-                DetailSection(title: "Library level") {
-                    VStack(spacing: 4) {
-                        ForEach(LibraryLevel.allCases) { level in
-                            HStack(spacing: 8) {
-                                Image(systemName: level.icon)
-                                    .frame(width: 16)
-                                    .foregroundStyle(.secondary)
-                                VStack(alignment: .leading, spacing: 1) {
-                                    Text(level.rawValue)
-                                        .font(.callout)
-                                    Text(level.description)
-                                        .font(.caption2)
-                                        .foregroundStyle(.tertiary)
-                                }
-                                Spacer()
-                                if item.libraryLevel == level {
-                                    Image(systemName: "checkmark")
-                                        .font(.caption.weight(.medium))
-                                        .foregroundStyle(.accentColor)
-                                }
-                            }
-                            .padding(.vertical, 5)
-                            .padding(.horizontal, 8)
-                            .background(
-                                RoundedRectangle(cornerRadius: 7)
-                                    .fill(item.libraryLevel == level ? Color.accentColor.opacity(0.07) : Color.clear)
-                            )
-                            .contentShape(Rectangle())
-                            .onTapGesture { item.libraryLevel = level }
-                        }
-                    }
-                }
-
+                libraryLevelSection
                 Divider().padding(.vertical, 8)
-
-                // ── Name ─────────────────────────────────────────────
-                DetailSection(title: "Name") {
-                    TextField("Name", text: $item.name)
-                        .textFieldStyle(.roundedBorder)
-                }
-
-                // ── Description ──────────────────────────────────────
-                DetailSection(title: "Description") {
-                    TextEditor(text: $item.description)
-                        .font(.callout)
-                        .frame(minHeight: 72)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 6)
-                                .stroke(Color.secondary.opacity(0.25), lineWidth: 0.5)
-                        )
-                }
-
+                nameSection
+                descriptionSection
                 Divider().padding(.vertical, 8)
-
-                // ── Queue for production ─────────────────────────────
-                DetailSection(title: "Production") {
-                    VStack(alignment: .leading, spacing: 8) {
-                        HStack {
-                            Text("Variants")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                            Spacer()
-                            Text("\(item.variantCount)")
-                                .font(.caption.monospacedDigit())
-                                .foregroundStyle(.secondary)
-                        }
-                        if let approved = item.approvedVariant {
-                            HStack {
-                                Text("Approved variant")
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                                Spacer()
-                                Text("#\(approved)")
-                                    .font(.caption.monospacedDigit())
-                                    .foregroundStyle(.green)
-                            }
-                        }
-                        Button {
-                            // TODO: queue logic
-                        } label: {
-                            Label("Queue for Production", systemImage: "film.stack")
-                                .frame(maxWidth: .infinity)
-                        }
-                        .buttonStyle(.borderedProminent)
-                        .controlSize(.regular)
-                        .disabled(item.name.trimmingCharacters(in: .whitespaces).isEmpty)
-                    }
-                }
-
+                productionSection
                 Spacer(minLength: 20)
             }
             .padding(14)
@@ -197,17 +61,155 @@ struct CastingItemDetailView: View {
         .background(Color(NSColor.windowBackgroundColor))
     }
 
-    private var typeLabel: String {
-        item.type == .character ? "Character" : "Location"
+    // MARK: Sub-sections (split out to help the type-checker)
+
+    @ViewBuilder private var thumbnailSection: some View {
+        ZStack(alignment: .topLeading) {
+            RoundedRectangle(cornerRadius: 10)
+                .fill(thumbnailColor.opacity(0.12))
+                .frame(maxWidth: .infinity)
+                .frame(height: 160)
+                .overlay {
+                    Image(systemName: thumbnailIcon)
+                        .font(.system(size: 52))
+                        .foregroundStyle(thumbnailColor.opacity(0.6))
+                }
+            Text(typeLabel)
+                .font(.caption.weight(.medium))
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(.thinMaterial, in: Capsule())
+                .foregroundStyle(.secondary)
+                .padding(10)
+        }
+        .padding(.bottom, 16)
     }
 
-    private var thumbnailColor: Color {
-        item.type == .character ? .blue : .teal
+    @ViewBuilder private var statusSection: some View {
+        DetailSection(title: "Status") {
+            VStack(spacing: 4) {
+                ForEach(GenerationStatus.allCases) { s in
+                    HStack(spacing: 8) {
+                        Circle()
+                            .fill(s.color)
+                            .frame(width: 8, height: 8)
+                        Text(s.label)
+                            .font(.callout)
+                        Spacer()
+                        if item.status == s {
+                            Image(systemName: "checkmark")
+                                .font(.caption.weight(.medium))
+                                .foregroundStyle(.accentColor)
+                        }
+                    }
+                    .padding(.vertical, 5)
+                    .padding(.horizontal, 8)
+                    .background(
+                        RoundedRectangle(cornerRadius: 7)
+                            .fill(item.status == s ? Color.accentColor.opacity(0.07) : Color.clear)
+                    )
+                    .contentShape(Rectangle())
+                    .onTapGesture { item.status = s }
+                }
+            }
+        }
     }
 
-    private var thumbnailIcon: String {
-        item.type == .character ? "person.fill" : "map"
+    @ViewBuilder private var libraryLevelSection: some View {
+        DetailSection(title: "Library level") {
+            VStack(spacing: 4) {
+                ForEach(LibraryLevel.allCases) { level in
+                    HStack(spacing: 8) {
+                        Image(systemName: level.icon)
+                            .frame(width: 16)
+                            .foregroundStyle(.secondary)
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text(level.rawValue)
+                                .font(.callout)
+                            Text(level.description)
+                                .font(.caption2)
+                                .foregroundStyle(.tertiary)
+                        }
+                        Spacer()
+                        if item.libraryLevel == level {
+                            Image(systemName: "checkmark")
+                                .font(.caption.weight(.medium))
+                                .foregroundStyle(.accentColor)
+                        }
+                    }
+                    .padding(.vertical, 5)
+                    .padding(.horizontal, 8)
+                    .background(
+                        RoundedRectangle(cornerRadius: 7)
+                            .fill(item.libraryLevel == level ? Color.accentColor.opacity(0.07) : Color.clear)
+                    )
+                    .contentShape(Rectangle())
+                    .onTapGesture { item.libraryLevel = level }
+                }
+            }
+        }
     }
+
+    @ViewBuilder private var nameSection: some View {
+        DetailSection(title: "Name") {
+            TextField("Name", text: $item.name)
+                .textFieldStyle(.roundedBorder)
+        }
+    }
+
+    @ViewBuilder private var descriptionSection: some View {
+        DetailSection(title: "Description") {
+            TextEditor(text: $item.description)
+                .font(.callout)
+                .frame(minHeight: 72)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .stroke(Color.secondary.opacity(0.25), lineWidth: 0.5)
+                )
+        }
+    }
+
+    @ViewBuilder private var productionSection: some View {
+        DetailSection(title: "Production") {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text("Variants")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Text("\(item.variantCount)")
+                        .font(.caption.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                }
+                if let approved = item.approvedVariant {
+                    HStack {
+                        Text("Approved variant")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Text("#\(approved)")
+                            .font(.caption.monospacedDigit())
+                            .foregroundStyle(.green)
+                    }
+                }
+                Button {
+                    // TODO: queue logic
+                } label: {
+                    Label("Queue for Production", systemImage: "film.stack")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.regular)
+                .disabled(item.name.trimmingCharacters(in: .whitespaces).isEmpty)
+            }
+        }
+    }
+
+    // MARK: Helpers
+
+    private var typeLabel: String      { item.type == .character ? "Character" : "Location" }
+    private var thumbnailColor: Color  { item.type == .character ? .blue : .teal }
+    private var thumbnailIcon: String  { item.type == .character ? "person.fill" : "map" }
 }
 
 // MARK: - Generic detail (non-casting)
@@ -228,9 +230,9 @@ private struct GenericDetailView: View {
                     }
                 Text(item.name).font(.title3.bold())
                 Divider()
-                LabeledContent("Status") { Text(item.status).foregroundStyle(.secondary) }
+                LabeledContent("Status")   { Text(item.status).foregroundStyle(.secondary) }
                 LabeledContent("Variants") { Text("\(item.variantCount)").foregroundStyle(.secondary) }
-                LabeledContent("ID") { Text(item.id).font(.caption.monospaced()).foregroundStyle(.tertiary) }
+                LabeledContent("ID")       { Text(item.id).font(.caption.monospaced()).foregroundStyle(.tertiary) }
                 Spacer()
             }
             .padding(14)
@@ -239,7 +241,7 @@ private struct GenericDetailView: View {
     }
 }
 
-// MARK: - Helper
+// MARK: - Helper view
 
 private struct DetailSection<Content: View>: View {
     let title: String

--- a/DrawThingsStoryboard/Features/ItemBrowser/ItemDetailView.swift
+++ b/DrawThingsStoryboard/Features/ItemBrowser/ItemDetailView.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+
+/// Right pane: properties panel for the selected item.
+/// Shows a placeholder when nothing is selected.
+struct ItemDetailView: View {
+
+    let section: AppSection?
+    let itemID: String?
+
+    private var item: MockItem? {
+        guard let itemID else { return nil }
+        return MockItems.items(for: section).first { $0.id == itemID }
+    }
+
+    var body: some View {
+        if let item {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+
+                    // ── Thumbnail placeholder ────────────────────────
+                    RoundedRectangle(cornerRadius: 12)
+                        .fill(item.color.opacity(0.15))
+                        .overlay {
+                            Image(systemName: item.icon)
+                                .font(.system(size: 60))
+                                .foregroundStyle(item.color)
+                        }
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 200)
+
+                    // ── Name ─────────────────────────────────────────
+                    VStack(alignment: .leading, spacing: 4) {
+                        Label("Name", systemImage: "textformat")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Text(item.name)
+                            .font(.title3.bold())
+                    }
+
+                    Divider()
+
+                    // ── Meta properties (mock) ────────────────────────
+                    PropertyRow(label: "Section", value: section?.title ?? "—")
+                    PropertyRow(label: "Status", value: item.status)
+                    PropertyRow(label: "Variants", value: "\(item.variantCount)")
+                    PropertyRow(label: "ID", value: item.id)
+
+                    Spacer()
+                }
+                .padding(16)
+            }
+            .background(Color(NSColor.windowBackgroundColor))
+        } else {
+            ContentUnavailableView(
+                "Nothing selected",
+                systemImage: "square.dashed",
+                description: Text("Select an item from the browser to see its properties.")
+            )
+        }
+    }
+}
+
+// MARK: - Property Row
+
+private struct PropertyRow: View {
+    let label: String
+    let value: String
+
+    var body: some View {
+        HStack(alignment: .top) {
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .frame(width: 70, alignment: .leading)
+            Text(value)
+                .font(.caption)
+                .foregroundStyle(.primary)
+        }
+    }
+}
+
+#Preview {
+    ItemDetailView(section: .casting, itemID: "c-01")
+        .frame(width: 280, height: 600)
+}

--- a/DrawThingsStoryboard/Features/ItemBrowser/ItemDetailView.swift
+++ b/DrawThingsStoryboard/Features/ItemBrowser/ItemDetailView.swift
@@ -36,10 +36,9 @@ struct ItemDetailView: View {
     }
 }
 
-// MARK: - Casting detail (top-level coordinator)
+// MARK: - Casting detail
 
 struct CastingItemDetailView: View {
-
     @Binding var item: CastingItem
 
     var body: some View {
@@ -62,10 +61,14 @@ struct CastingItemDetailView: View {
     }
 }
 
-// MARK: - Sub-section structs
+// MARK: - ThumbnailSection
 
 private struct ThumbnailSection: View {
     let item: CastingItem
+    private var typeLabel: String     { item.type == .character ? "Character" : "Location" }
+    private var thumbnailColor: Color { item.type == .character ? .blue : .teal }
+    private var thumbnailIcon: String { item.type == .character ? "person.fill" : "map" }
+
     var body: some View {
         ZStack(alignment: .topLeading) {
             RoundedRectangle(cornerRadius: 10)
@@ -87,100 +90,120 @@ private struct ThumbnailSection: View {
         }
         .padding(.bottom, 16)
     }
-    private var typeLabel: String     { item.type == .character ? "Character" : "Location" }
-    private var thumbnailColor: Color { item.type == .character ? .blue : .teal }
-    private var thumbnailIcon: String { item.type == .character ? "person.fill" : "map" }
 }
+
+// MARK: - StatusSection
 
 private struct StatusSection: View {
     @Binding var item: CastingItem
+
     var body: some View {
-        DetailSection(title: "Status") {
+        VStack(alignment: .leading, spacing: 6) {
+            sectionLabel("Status")
             VStack(spacing: 4) {
-                ForEach(GenerationStatus.allCases) { s in
-                    HStack(spacing: 8) {
-                        Circle()
-                            .fill(s.color)
-                            .frame(width: 8, height: 8)
-                        Text(s.label)
-                            .font(.callout)
-                        Spacer()
-                        if item.status == s {
-                            Image(systemName: "checkmark")
-                                .font(.caption.weight(.medium))
-                                .foregroundStyle(.accentColor)
-                        }
-                    }
-                    .padding(.vertical, 5)
-                    .padding(.horizontal, 8)
-                    .background(
-                        RoundedRectangle(cornerRadius: 7)
-                            .fill(item.status == s
-                                  ? Color.accentColor.opacity(0.07)
-                                  : Color.clear)
-                    )
-                    .contentShape(Rectangle())
-                    .onTapGesture { item.status = s }
-                }
+                statusRow(GenerationStatus.notYetGenerated)
+                statusRow(GenerationStatus.previewGenerated)
+                statusRow(GenerationStatus.finalGenerated)
             }
         }
+        .padding(.bottom, 12)
+    }
+
+    private func statusRow(_ s: GenerationStatus) -> some View {
+        HStack(spacing: 8) {
+            Circle()
+                .fill(s.color)
+                .frame(width: 8, height: 8)
+            Text(s.label)
+                .font(.callout)
+            Spacer()
+            if item.status == s {
+                Image(systemName: "checkmark")
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(.accentColor)
+            }
+        }
+        .padding(.vertical, 5)
+        .padding(.horizontal, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 7)
+                .fill(item.status == s ? Color.accentColor.opacity(0.07) : Color.clear)
+        )
+        .contentShape(Rectangle())
+        .onTapGesture { item.status = s }
     }
 }
+
+// MARK: - LibraryLevelSection
 
 private struct LibraryLevelSection: View {
     @Binding var item: CastingItem
+
     var body: some View {
-        DetailSection(title: "Library level") {
+        VStack(alignment: .leading, spacing: 6) {
+            sectionLabel("Library level")
             VStack(spacing: 4) {
-                ForEach(LibraryLevel.allCases) { level in
-                    HStack(spacing: 8) {
-                        Image(systemName: level.icon)
-                            .frame(width: 16)
-                            .foregroundStyle(.secondary)
-                        VStack(alignment: .leading, spacing: 1) {
-                            Text(level.rawValue)
-                                .font(.callout)
-                            Text(level.description)
-                                .font(.caption2)
-                                .foregroundStyle(.tertiary)
-                        }
-                        Spacer()
-                        if item.libraryLevel == level {
-                            Image(systemName: "checkmark")
-                                .font(.caption.weight(.medium))
-                                .foregroundStyle(.accentColor)
-                        }
-                    }
-                    .padding(.vertical, 5)
-                    .padding(.horizontal, 8)
-                    .background(
-                        RoundedRectangle(cornerRadius: 7)
-                            .fill(item.libraryLevel == level
-                                  ? Color.accentColor.opacity(0.07)
-                                  : Color.clear)
-                    )
-                    .contentShape(Rectangle())
-                    .onTapGesture { item.libraryLevel = level }
-                }
+                levelRow(LibraryLevel.studio)
+                levelRow(LibraryLevel.customer)
+                levelRow(LibraryLevel.episode)
             }
         }
+        .padding(.bottom, 12)
+    }
+
+    private func levelRow(_ level: LibraryLevel) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: level.icon)
+                .frame(width: 16)
+                .foregroundStyle(.secondary)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(level.rawValue)
+                    .font(.callout)
+                Text(level.description)
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+            Spacer()
+            if item.libraryLevel == level {
+                Image(systemName: "checkmark")
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(.accentColor)
+            }
+        }
+        .padding(.vertical, 5)
+        .padding(.horizontal, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 7)
+                .fill(item.libraryLevel == level ? Color.accentColor.opacity(0.07) : Color.clear)
+        )
+        .contentShape(Rectangle())
+        .onTapGesture { item.libraryLevel = level }
     }
 }
+
+// MARK: - NameSection
 
 private struct NameSection: View {
     @Binding var item: CastingItem
+
     var body: some View {
-        DetailSection(title: "Name") {
+        VStack(alignment: .leading, spacing: 6) {
+            sectionLabel("Name")
             TextField("Name", text: $item.name)
                 .textFieldStyle(.roundedBorder)
         }
+        .padding(.bottom, 12)
     }
 }
 
+// MARK: - DescriptionSection
+
 private struct DescriptionSection: View {
     @Binding var item: CastingItem
+
     var body: some View {
-        DetailSection(title: "Description") {
+        VStack(alignment: .leading, spacing: 6) {
+            sectionLabel("Description")
             TextEditor(text: $item.description)
                 .font(.callout)
                 .frame(minHeight: 72)
@@ -189,13 +212,18 @@ private struct DescriptionSection: View {
                         .stroke(Color.secondary.opacity(0.25), lineWidth: 0.5)
                 )
         }
+        .padding(.bottom, 12)
     }
 }
 
+// MARK: - ProductionSection
+
 private struct ProductionSection: View {
     @Binding var item: CastingItem
+
     var body: some View {
-        DetailSection(title: "Production") {
+        VStack(alignment: .leading, spacing: 6) {
+            sectionLabel("Production")
             VStack(alignment: .leading, spacing: 8) {
                 HStack {
                     Text("Variants")
@@ -228,13 +256,15 @@ private struct ProductionSection: View {
                 .disabled(item.name.trimmingCharacters(in: .whitespaces).isEmpty)
             }
         }
+        .padding(.bottom, 12)
     }
 }
 
-// MARK: - Generic detail (non-casting)
+// MARK: - Generic detail
 
 private struct GenericDetailView: View {
     let item: MockItem
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 12) {
@@ -260,22 +290,14 @@ private struct GenericDetailView: View {
     }
 }
 
-// MARK: - Shared helper
+// MARK: - Shared free function (avoids generic DetailSection entirely)
 
-private struct DetailSection<Content: View>: View {
-    let title: String
-    @ViewBuilder let content: () -> Content
-    var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text(title)
-                .font(.caption)
-                .foregroundStyle(.tertiary)
-                .textCase(.uppercase)
-                .tracking(0.5)
-            content()
-        }
-        .padding(.bottom, 12)
-    }
+private func sectionLabel(_ title: String) -> some View {
+    Text(title)
+        .font(.caption)
+        .foregroundStyle(.tertiary)
+        .textCase(.uppercase)
+        .tracking(0.5)
 }
 
 #Preview {

--- a/DrawThingsStoryboard/Features/ItemBrowser/ItemDetailView.swift
+++ b/DrawThingsStoryboard/Features/ItemBrowser/ItemDetailView.swift
@@ -36,7 +36,7 @@ struct ItemDetailView: View {
     }
 }
 
-// MARK: - Casting detail
+// MARK: - Casting detail (top-level coordinator)
 
 struct CastingItemDetailView: View {
 
@@ -45,25 +45,28 @@ struct CastingItemDetailView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
-                thumbnailSection
-                statusSection
+                ThumbnailSection(item: item)
+                StatusSection(item: $item)
                 Divider().padding(.vertical, 8)
-                libraryLevelSection
+                LibraryLevelSection(item: $item)
                 Divider().padding(.vertical, 8)
-                nameSection
-                descriptionSection
+                NameSection(item: $item)
+                DescriptionSection(item: $item)
                 Divider().padding(.vertical, 8)
-                productionSection
+                ProductionSection(item: $item)
                 Spacer(minLength: 20)
             }
             .padding(14)
         }
         .background(Color(NSColor.windowBackgroundColor))
     }
+}
 
-    // MARK: Sub-sections (split out to help the type-checker)
+// MARK: - Sub-section structs
 
-    @ViewBuilder private var thumbnailSection: some View {
+private struct ThumbnailSection: View {
+    let item: CastingItem
+    var body: some View {
         ZStack(alignment: .topLeading) {
             RoundedRectangle(cornerRadius: 10)
                 .fill(thumbnailColor.opacity(0.12))
@@ -84,8 +87,14 @@ struct CastingItemDetailView: View {
         }
         .padding(.bottom, 16)
     }
+    private var typeLabel: String     { item.type == .character ? "Character" : "Location" }
+    private var thumbnailColor: Color { item.type == .character ? .blue : .teal }
+    private var thumbnailIcon: String { item.type == .character ? "person.fill" : "map" }
+}
 
-    @ViewBuilder private var statusSection: some View {
+private struct StatusSection: View {
+    @Binding var item: CastingItem
+    var body: some View {
         DetailSection(title: "Status") {
             VStack(spacing: 4) {
                 ForEach(GenerationStatus.allCases) { s in
@@ -106,7 +115,9 @@ struct CastingItemDetailView: View {
                     .padding(.horizontal, 8)
                     .background(
                         RoundedRectangle(cornerRadius: 7)
-                            .fill(item.status == s ? Color.accentColor.opacity(0.07) : Color.clear)
+                            .fill(item.status == s
+                                  ? Color.accentColor.opacity(0.07)
+                                  : Color.clear)
                     )
                     .contentShape(Rectangle())
                     .onTapGesture { item.status = s }
@@ -114,8 +125,11 @@ struct CastingItemDetailView: View {
             }
         }
     }
+}
 
-    @ViewBuilder private var libraryLevelSection: some View {
+private struct LibraryLevelSection: View {
+    @Binding var item: CastingItem
+    var body: some View {
         DetailSection(title: "Library level") {
             VStack(spacing: 4) {
                 ForEach(LibraryLevel.allCases) { level in
@@ -141,7 +155,9 @@ struct CastingItemDetailView: View {
                     .padding(.horizontal, 8)
                     .background(
                         RoundedRectangle(cornerRadius: 7)
-                            .fill(item.libraryLevel == level ? Color.accentColor.opacity(0.07) : Color.clear)
+                            .fill(item.libraryLevel == level
+                                  ? Color.accentColor.opacity(0.07)
+                                  : Color.clear)
                     )
                     .contentShape(Rectangle())
                     .onTapGesture { item.libraryLevel = level }
@@ -149,15 +165,21 @@ struct CastingItemDetailView: View {
             }
         }
     }
+}
 
-    @ViewBuilder private var nameSection: some View {
+private struct NameSection: View {
+    @Binding var item: CastingItem
+    var body: some View {
         DetailSection(title: "Name") {
             TextField("Name", text: $item.name)
                 .textFieldStyle(.roundedBorder)
         }
     }
+}
 
-    @ViewBuilder private var descriptionSection: some View {
+private struct DescriptionSection: View {
+    @Binding var item: CastingItem
+    var body: some View {
         DetailSection(title: "Description") {
             TextEditor(text: $item.description)
                 .font(.callout)
@@ -168,8 +190,11 @@ struct CastingItemDetailView: View {
                 )
         }
     }
+}
 
-    @ViewBuilder private var productionSection: some View {
+private struct ProductionSection: View {
+    @Binding var item: CastingItem
+    var body: some View {
         DetailSection(title: "Production") {
             VStack(alignment: .leading, spacing: 8) {
                 HStack {
@@ -204,12 +229,6 @@ struct CastingItemDetailView: View {
             }
         }
     }
-
-    // MARK: Helpers
-
-    private var typeLabel: String      { item.type == .character ? "Character" : "Location" }
-    private var thumbnailColor: Color  { item.type == .character ? .blue : .teal }
-    private var thumbnailIcon: String  { item.type == .character ? "person.fill" : "map" }
 }
 
 // MARK: - Generic detail (non-casting)
@@ -241,7 +260,7 @@ private struct GenericDetailView: View {
     }
 }
 
-// MARK: - Helper view
+// MARK: - Shared helper
 
 private struct DetailSection<Content: View>: View {
     let title: String

--- a/DrawThingsStoryboard/Features/ItemBrowser/ItemDetailView.swift
+++ b/DrawThingsStoryboard/Features/ItemBrowser/ItemDetailView.swift
@@ -1,85 +1,264 @@
 import SwiftUI
 
-/// Right pane: properties panel for the selected item.
-/// Shows a placeholder when nothing is selected.
+/// Right pane — switches between casting detail and generic detail.
 struct ItemDetailView: View {
 
     let section: AppSection?
-    let itemID: String?
-
-    private var item: MockItem? {
-        guard let itemID else { return nil }
-        return MockItems.items(for: section).first { $0.id == itemID }
-    }
+    @Binding var selectedCastingItem: CastingItem?
+    let selectedItemID: String?
 
     var body: some View {
-        if let item {
-            ScrollView {
-                VStack(alignment: .leading, spacing: 20) {
-
-                    // ── Thumbnail placeholder ────────────────────────
-                    RoundedRectangle(cornerRadius: 12)
-                        .fill(item.color.opacity(0.15))
-                        .overlay {
-                            Image(systemName: item.icon)
-                                .font(.system(size: 60))
-                                .foregroundStyle(item.color)
-                        }
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 200)
-
-                    // ── Name ─────────────────────────────────────────
-                    VStack(alignment: .leading, spacing: 4) {
-                        Label("Name", systemImage: "textformat")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                        Text(item.name)
-                            .font(.title3.bold())
-                    }
-
-                    Divider()
-
-                    // ── Meta properties (mock) ────────────────────────
-                    PropertyRow(label: "Section", value: section?.title ?? "—")
-                    PropertyRow(label: "Status", value: item.status)
-                    PropertyRow(label: "Variants", value: "\(item.variantCount)")
-                    PropertyRow(label: "ID", value: item.id)
-
-                    Spacer()
-                }
-                .padding(16)
+        if section == .casting {
+            if let item = selectedCastingItem {
+                CastingItemDetailView(item: Binding(
+                    get: { item },
+                    set: { selectedCastingItem = $0 }
+                ))
+            } else {
+                emptyState
             }
-            .background(Color(NSColor.windowBackgroundColor))
         } else {
-            ContentUnavailableView(
-                "Nothing selected",
-                systemImage: "square.dashed",
-                description: Text("Select an item from the browser to see its properties.")
-            )
+            if let itemID = selectedItemID,
+               let item = MockData.items(for: section).first(where: { $0.id == itemID }) {
+                GenericDetailView(item: item)
+            } else {
+                emptyState
+            }
         }
+    }
+
+    private var emptyState: some View {
+        ContentUnavailableView(
+            "Nothing selected",
+            systemImage: "square.dashed",
+            description: Text("Select an item to see its properties.")
+        )
     }
 }
 
-// MARK: - Property Row
+// MARK: - Casting detail
 
-private struct PropertyRow: View {
-    let label: String
-    let value: String
+struct CastingItemDetailView: View {
+
+    @Binding var item: CastingItem
 
     var body: some View {
-        HStack(alignment: .top) {
-            Text(label)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .frame(width: 70, alignment: .leading)
-            Text(value)
-                .font(.caption)
-                .foregroundStyle(.primary)
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+
+                // ── Type badge + thumbnail placeholder ───────────────
+                ZStack(alignment: .topLeading) {
+                    RoundedRectangle(cornerRadius: 10)
+                        .fill(thumbnailColor.opacity(0.12))
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 160)
+                        .overlay {
+                            Image(systemName: thumbnailIcon)
+                                .font(.system(size: 52))
+                                .foregroundStyle(thumbnailColor.opacity(0.6))
+                        }
+
+                    // Type label
+                    Text(typeLabel)
+                        .font(.caption.weight(.medium))
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(.thinMaterial, in: Capsule())
+                        .foregroundStyle(.secondary)
+                        .padding(10)
+                }
+                .padding(.bottom, 16)
+
+                // ── Status ───────────────────────────────────────────
+                DetailSection(title: "Status") {
+                    VStack(spacing: 4) {
+                        ForEach(GenerationStatus.allCases) { s in
+                            HStack(spacing: 8) {
+                                Circle()
+                                    .fill(s.color)
+                                    .frame(width: 8, height: 8)
+                                Text(s.label)
+                                    .font(.callout)
+                                Spacer()
+                                if item.status == s {
+                                    Image(systemName: "checkmark")
+                                        .font(.caption.weight(.medium))
+                                        .foregroundStyle(.accentColor)
+                                }
+                            }
+                            .padding(.vertical, 5)
+                            .padding(.horizontal, 8)
+                            .background(
+                                RoundedRectangle(cornerRadius: 7)
+                                    .fill(item.status == s ? Color.accentColor.opacity(0.07) : Color.clear)
+                            )
+                            .contentShape(Rectangle())
+                            .onTapGesture { item.status = s }
+                        }
+                    }
+                }
+
+                Divider().padding(.vertical, 8)
+
+                // ── Library level ────────────────────────────────────
+                DetailSection(title: "Library level") {
+                    VStack(spacing: 4) {
+                        ForEach(LibraryLevel.allCases) { level in
+                            HStack(spacing: 8) {
+                                Image(systemName: level.icon)
+                                    .frame(width: 16)
+                                    .foregroundStyle(.secondary)
+                                VStack(alignment: .leading, spacing: 1) {
+                                    Text(level.rawValue)
+                                        .font(.callout)
+                                    Text(level.description)
+                                        .font(.caption2)
+                                        .foregroundStyle(.tertiary)
+                                }
+                                Spacer()
+                                if item.libraryLevel == level {
+                                    Image(systemName: "checkmark")
+                                        .font(.caption.weight(.medium))
+                                        .foregroundStyle(.accentColor)
+                                }
+                            }
+                            .padding(.vertical, 5)
+                            .padding(.horizontal, 8)
+                            .background(
+                                RoundedRectangle(cornerRadius: 7)
+                                    .fill(item.libraryLevel == level ? Color.accentColor.opacity(0.07) : Color.clear)
+                            )
+                            .contentShape(Rectangle())
+                            .onTapGesture { item.libraryLevel = level }
+                        }
+                    }
+                }
+
+                Divider().padding(.vertical, 8)
+
+                // ── Name ─────────────────────────────────────────────
+                DetailSection(title: "Name") {
+                    TextField("Name", text: $item.name)
+                        .textFieldStyle(.roundedBorder)
+                }
+
+                // ── Description ──────────────────────────────────────
+                DetailSection(title: "Description") {
+                    TextEditor(text: $item.description)
+                        .font(.callout)
+                        .frame(minHeight: 72)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 6)
+                                .stroke(Color.secondary.opacity(0.25), lineWidth: 0.5)
+                        )
+                }
+
+                Divider().padding(.vertical, 8)
+
+                // ── Queue for production ─────────────────────────────
+                DetailSection(title: "Production") {
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack {
+                            Text("Variants")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            Spacer()
+                            Text("\(item.variantCount)")
+                                .font(.caption.monospacedDigit())
+                                .foregroundStyle(.secondary)
+                        }
+                        if let approved = item.approvedVariant {
+                            HStack {
+                                Text("Approved variant")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                Spacer()
+                                Text("#\(approved)")
+                                    .font(.caption.monospacedDigit())
+                                    .foregroundStyle(.green)
+                            }
+                        }
+                        Button {
+                            // TODO: queue logic
+                        } label: {
+                            Label("Queue for Production", systemImage: "film.stack")
+                                .frame(maxWidth: .infinity)
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.regular)
+                        .disabled(item.name.trimmingCharacters(in: .whitespaces).isEmpty)
+                    }
+                }
+
+                Spacer(minLength: 20)
+            }
+            .padding(14)
         }
+        .background(Color(NSColor.windowBackgroundColor))
+    }
+
+    private var typeLabel: String {
+        item.type == .character ? "Character" : "Location"
+    }
+
+    private var thumbnailColor: Color {
+        item.type == .character ? .blue : .teal
+    }
+
+    private var thumbnailIcon: String {
+        item.type == .character ? "person.fill" : "map"
+    }
+}
+
+// MARK: - Generic detail (non-casting)
+
+private struct GenericDetailView: View {
+    let item: MockItem
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(item.color.opacity(0.12))
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 140)
+                    .overlay {
+                        Image(systemName: item.icon)
+                            .font(.system(size: 44))
+                            .foregroundStyle(item.color)
+                    }
+                Text(item.name).font(.title3.bold())
+                Divider()
+                LabeledContent("Status") { Text(item.status).foregroundStyle(.secondary) }
+                LabeledContent("Variants") { Text("\(item.variantCount)").foregroundStyle(.secondary) }
+                LabeledContent("ID") { Text(item.id).font(.caption.monospaced()).foregroundStyle(.tertiary) }
+                Spacer()
+            }
+            .padding(14)
+        }
+        .background(Color(NSColor.windowBackgroundColor))
+    }
+}
+
+// MARK: - Helper
+
+private struct DetailSection<Content: View>: View {
+    let title: String
+    @ViewBuilder let content: () -> Content
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+                .textCase(.uppercase)
+                .tracking(0.5)
+            content()
+        }
+        .padding(.bottom, 12)
     }
 }
 
 #Preview {
-    ItemDetailView(section: .casting, itemID: "c-01")
-        .frame(width: 280, height: 600)
+    @Previewable @State var item: CastingItem? = MockData.castingCharacters.first
+    ItemDetailView(section: .casting, selectedCastingItem: $item, selectedItemID: nil)
+        .frame(width: 280, height: 700)
 }

--- a/DrawThingsStoryboard/Features/ItemBrowser/ItemDetailView.swift
+++ b/DrawThingsStoryboard/Features/ItemBrowser/ItemDetailView.swift
@@ -120,7 +120,7 @@ private struct StatusSection: View {
             if item.status == s {
                 Image(systemName: "checkmark")
                     .font(.caption.weight(.medium))
-                    .foregroundStyle(.accentColor)
+                    .foregroundStyle(Color.accentColor)
             }
         }
         .padding(.vertical, 5)
@@ -167,7 +167,7 @@ private struct LibraryLevelSection: View {
             if item.libraryLevel == level {
                 Image(systemName: "checkmark")
                     .font(.caption.weight(.medium))
-                    .foregroundStyle(.accentColor)
+                    .foregroundStyle(Color.accentColor)
             }
         }
         .padding(.vertical, 5)
@@ -242,7 +242,7 @@ private struct ProductionSection: View {
                         Spacer()
                         Text("#\(approved)")
                             .font(.caption.monospacedDigit())
-                            .foregroundStyle(.green)
+                            .foregroundStyle(Color.green)
                     }
                 }
                 Button {
@@ -290,7 +290,7 @@ private struct GenericDetailView: View {
     }
 }
 
-// MARK: - Shared free function (avoids generic DetailSection entirely)
+// MARK: - Shared free function
 
 private func sectionLabel(_ title: String) -> some View {
     Text(title)

--- a/DrawThingsStoryboard/Features/Library/LibraryView.swift
+++ b/DrawThingsStoryboard/Features/Library/LibraryView.swift
@@ -1,0 +1,348 @@
+import SwiftUI
+
+/// Library view — lets the user navigate the asset hierarchy:
+/// Studio  →  Customer  →  Episode
+/// At each level, Cast and Locations sub-sections are shown.
+struct LibraryView: View {
+
+    // Navigation state
+    @State private var selectedCustomerID: String? = nil
+    @State private var selectedEpisodeID:  String? = nil
+    @State private var selectedItem: CastingItem? = nil
+
+    private var studio: MockStudio { MockData.libraryTree }
+
+    private var selectedCustomer: MockCustomer? {
+        guard let id = selectedCustomerID else { return nil }
+        return studio.customers.first { $0.id == id }
+    }
+
+    private var selectedEpisode: MockEpisode? {
+        guard let id = selectedEpisodeID else { return nil }
+        return selectedCustomer?.episodes.first { $0.id == id }
+    }
+
+    // Derived: which characters/locations to show in center pane
+    private var visibleCharacters: [CastingItem] {
+        if let ep = selectedEpisode  { return ep.characters }
+        if let cu = selectedCustomer { return cu.episodes.flatMap(\.characters) }
+        return studio.customers.flatMap { $0.episodes.flatMap(\.characters) } + studio.characters
+    }
+
+    private var visibleLocations: [CastingItem] {
+        if let ep = selectedEpisode  { return ep.locations }
+        if let cu = selectedCustomer { return cu.episodes.flatMap(\.locations) }
+        return studio.customers.flatMap { $0.episodes.flatMap(\.locations) } + studio.locations
+    }
+
+    var body: some View {
+        HSplitView {
+            // ── Left: level navigator ────────────────────────────────
+            LibraryLevelNavigator(
+                studio: studio,
+                selectedCustomerID: $selectedCustomerID,
+                selectedEpisodeID: $selectedEpisodeID
+            )
+            .frame(minWidth: 180, idealWidth: 210, maxWidth: 240)
+
+            // ── Center: item grid ────────────────────────────────────
+            LibraryItemBrowser(
+                characters: visibleCharacters,
+                locations: visibleLocations,
+                selectedItem: $selectedItem,
+                levelLabel: currentLevelLabel
+            )
+            .frame(minWidth: 280)
+
+            // ── Right: detail ────────────────────────────────────────
+            Group {
+                if var item = selectedItem {
+                    CastingItemDetailView(item: Binding(
+                        get: { item },
+                        set: { selectedItem = $0; item = $0 }
+                    ))
+                } else {
+                    ContentUnavailableView(
+                        "Nothing selected",
+                        systemImage: "square.dashed",
+                        description: Text("Select an asset to see its properties.")
+                    )
+                }
+            }
+            .frame(minWidth: 260, idealWidth: 280, maxWidth: 320)
+        }
+        .onChange(of: selectedCustomerID) { _, _ in
+            selectedEpisodeID = nil
+            selectedItem = nil
+        }
+        .onChange(of: selectedEpisodeID) { _, _ in
+            selectedItem = nil
+        }
+    }
+
+    private var currentLevelLabel: String {
+        if let ep = selectedEpisode   { return ep.name }
+        if let cu = selectedCustomer  { return cu.name }
+        return studio.name
+    }
+}
+
+// MARK: - Level navigator (left panel inside Library)
+
+private struct LibraryLevelNavigator: View {
+
+    let studio: MockStudio
+    @Binding var selectedCustomerID: String?
+    @Binding var selectedEpisodeID: String?
+
+    var body: some View {
+        List(selection: $selectedCustomerID) {
+
+            // Studio level row
+            HStack(spacing: 6) {
+                Image(systemName: "building.columns")
+                    .foregroundStyle(.purple)
+                    .frame(width: 16)
+                Text(studio.name)
+                    .font(.callout.weight(.medium))
+            }
+            .padding(.vertical, 2)
+            .tag(Optional<String>.none as String?)
+            .onTapGesture {
+                selectedCustomerID = nil
+                selectedEpisodeID = nil
+            }
+
+            Divider()
+
+            // Customers + episodes
+            ForEach(studio.customers) { customer in
+                Section {
+                    ForEach(customer.episodes) { episode in
+                        HStack(spacing: 6) {
+                            Image(systemName: "film")
+                                .foregroundStyle(.blue)
+                                .font(.caption)
+                                .frame(width: 16)
+                            Text(episode.name)
+                                .font(.caption)
+                                .lineLimit(1)
+                        }
+                        .padding(.vertical, 1)
+                        .tag(episode.id)
+                        .onTapGesture {
+                            selectedCustomerID = customer.id
+                            selectedEpisodeID = episode.id
+                        }
+                    }
+                } header: {
+                    HStack(spacing: 6) {
+                        Image(systemName: "person.text.rectangle")
+                            .foregroundStyle(.teal)
+                            .frame(width: 16)
+                        Text(customer.name)
+                            .font(.caption.weight(.medium))
+                            .lineLimit(1)
+                    }
+                    .padding(.vertical, 2)
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        selectedCustomerID = customer.id
+                        selectedEpisodeID = nil
+                    }
+                }
+            }
+        }
+        .listStyle(.sidebar)
+        .navigationTitle("Library")
+    }
+}
+
+// MARK: - Item browser inside Library
+
+private struct LibraryItemBrowser: View {
+
+    let characters: [CastingItem]
+    let locations: [CastingItem]
+    @Binding var selectedItem: CastingItem?
+    let levelLabel: String
+
+    private let columns = [GridItem(.adaptive(minimum: 100, maximum: 140), spacing: 10)]
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                Image(systemName: "photo.stack")
+                    .font(.title2)
+                    .foregroundStyle(.secondary)
+                Text(levelLabel)
+                    .font(.title2.bold())
+                    .lineLimit(1)
+                Spacer()
+                Text("\(characters.count + locations.count) assets")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 12)
+
+            Divider()
+
+            ScrollView {
+                VStack(spacing: 0) {
+                    LibrarySubGrid(
+                        title: "Characters",
+                        items: characters,
+                        selectedItem: $selectedItem,
+                        columns: columns
+                    )
+
+                    Divider().padding(.vertical, 6)
+
+                    LibrarySubGrid(
+                        title: "Locations",
+                        items: locations,
+                        selectedItem: $selectedItem,
+                        columns: columns
+                    )
+                }
+                .padding(.bottom, 16)
+            }
+        }
+        .background(Color(NSColor.windowBackgroundColor))
+    }
+}
+
+// MARK: - Sub-grid (Characters or Locations) inside Library
+
+private struct LibrarySubGrid: View {
+
+    let title: String
+    let items: [CastingItem]
+    @Binding var selectedItem: CastingItem?
+    let columns: [GridItem]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Text(title)
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(.secondary)
+                Spacer()
+                // Library level badge legend
+                LibraryLevelBadgeLegend()
+            }
+            .padding(.horizontal, 14)
+            .padding(.top, 12)
+            .padding(.bottom, 6)
+
+            if items.isEmpty {
+                Text("No \(title.lowercased()) at this level.")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+                    .padding(.horizontal, 14)
+                    .padding(.bottom, 12)
+            } else {
+                LazyVGrid(columns: columns, spacing: 10) {
+                    ForEach(items) { item in
+                        LibraryTileView(item: item, isSelected: selectedItem?.id == item.id)
+                            .onTapGesture { selectedItem = item }
+                    }
+                }
+                .padding(.horizontal, 14)
+            }
+        }
+    }
+}
+
+// MARK: - Library tile (shows library level badge)
+
+private struct LibraryTileView: View {
+
+    let item: CastingItem
+    let isSelected: Bool
+
+    var body: some View {
+        VStack(spacing: 4) {
+            ZStack(alignment: .topTrailing) {
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(tileColor.opacity(0.13))
+                    .frame(height: 76)
+                    .overlay {
+                        Image(systemName: tileIcon)
+                            .font(.system(size: 26))
+                            .foregroundStyle(tileColor.opacity(0.7))
+                    }
+
+                // Library level badge
+                Text(item.libraryLevel.rawValue.prefix(2).uppercased())
+                    .font(.system(size: 9, weight: .bold))
+                    .padding(.horizontal, 4)
+                    .padding(.vertical, 2)
+                    .background(levelBadgeColor.opacity(0.2), in: RoundedRectangle(cornerRadius: 3))
+                    .foregroundStyle(levelBadgeColor)
+                    .padding(4)
+
+                // Status dot bottom-left
+                Circle()
+                    .fill(item.status.color)
+                    .frame(width: 7, height: 7)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
+                    .padding(5)
+            }
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(isSelected ? Color.accentColor : Color.clear, lineWidth: 1.5)
+            )
+
+            Text(item.name)
+                .font(.caption2)
+                .lineLimit(1)
+                .foregroundStyle(isSelected ? Color.accentColor : .primary)
+        }
+        .padding(4)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(isSelected ? Color.accentColor.opacity(0.07) : Color.clear)
+        )
+    }
+
+    private var tileColor: Color {
+        item.type == .character ? .blue : .teal
+    }
+
+    private var tileIcon: String {
+        item.type == .character ? "person.fill" : "map"
+    }
+
+    private var levelBadgeColor: Color {
+        switch item.libraryLevel {
+        case .studio:   return .purple
+        case .customer: return .teal
+        case .episode:  return .blue
+        }
+    }
+}
+
+// MARK: - Badge legend
+
+private struct LibraryLevelBadgeLegend: View {
+    var body: some View {
+        HStack(spacing: 6) {
+            ForEach([("ST", Color.purple), ("CU", .teal), ("EP", .blue)], id: \.0) { abbr, color in
+                Text(abbr)
+                    .font(.system(size: 9, weight: .bold))
+                    .padding(.horizontal, 4)
+                    .padding(.vertical, 2)
+                    .background(color.opacity(0.15), in: RoundedRectangle(cornerRadius: 3))
+                    .foregroundStyle(color)
+            }
+        }
+    }
+}
+
+#Preview {
+    LibraryView()
+        .frame(width: 900, height: 600)
+}

--- a/DrawThingsStoryboard/Models/MockItem.swift
+++ b/DrawThingsStoryboard/Models/MockItem.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+/// Lightweight placeholder item for UI prototyping.
+/// Replace with real domain models once filesystem layer is built.
+struct MockItem: Identifiable {
+    let id: String
+    let name: String
+    let icon: String
+    let color: Color
+    let status: String
+    let variantCount: Int
+}
+
+enum MockItems {
+
+    static func items(for section: AppSection?) -> [MockItem] {
+        switch section {
+        case .briefing:
+            return [
+                MockItem(id: "b-01", name: "Studio Config",      icon: "gearshape",          color: .indigo,  status: "Draft",    variantCount: 1),
+                MockItem(id: "b-02", name: "Episode Config",     icon: "doc.badge.gearshape", color: .indigo,  status: "Draft",    variantCount: 1),
+            ]
+        case .casting:
+            return [
+                MockItem(id: "c-01", name: "Alex — Hero",        icon: "person.fill",         color: .blue,    status: "Approved", variantCount: 3),
+                MockItem(id: "c-02", name: "Sam — Sidekick",     icon: "person.fill",         color: .cyan,    status: "Draft",    variantCount: 2),
+                MockItem(id: "c-03", name: "Jordan — Villain",   icon: "person.fill",         color: .red,     status: "Draft",    variantCount: 1),
+                MockItem(id: "c-04", name: "Rooftop — Night",    icon: "building.2",          color: .purple,  status: "Approved", variantCount: 4),
+                MockItem(id: "c-05", name: "Office — Day",       icon: "building.2",          color: .orange,  status: "Draft",    variantCount: 2),
+            ]
+        case .writing:
+            return [
+                MockItem(id: "w-01", name: "Act 1 — Setup",      icon: "doc.text",            color: .green,   status: "Draft",    variantCount: 1),
+                MockItem(id: "w-02", name: "Act 2 — Conflict",   icon: "doc.text",            color: .green,   status: "Draft",    variantCount: 1),
+                MockItem(id: "w-03", name: "Act 3 — Resolution", icon: "doc.text",            color: .green,   status: "Draft",    variantCount: 1),
+            ]
+        case .production:
+            return [
+                MockItem(id: "p-01", name: "Seq 01 — Sc 01",     icon: "photo",               color: .yellow,  status: "Draft",    variantCount: 2),
+                MockItem(id: "p-02", name: "Seq 01 — Sc 02",     icon: "photo",               color: .yellow,  status: "Approved", variantCount: 1),
+                MockItem(id: "p-03", name: "Seq 01 — Sc 03",     icon: "photo",               color: .yellow,  status: "Draft",    variantCount: 3),
+                MockItem(id: "p-04", name: "Seq 02 — Sc 01",     icon: "photo",               color: .orange,  status: "Draft",    variantCount: 1),
+            ]
+        case .library:
+            return [
+                MockItem(id: "l-01", name: "studio_main",        icon: "building.columns",    color: .teal,    status: "Active",   variantCount: 12),
+                MockItem(id: "l-02", name: "customer_acme",      icon: "person.text.rectangle",color: .teal,   status: "Active",   variantCount: 6),
+            ]
+        case .none:
+            return []
+        }
+    }
+}

--- a/DrawThingsStoryboard/Models/MockItem.swift
+++ b/DrawThingsStoryboard/Models/MockItem.swift
@@ -4,7 +4,7 @@ import SwiftUI
 
 /// Generation lifecycle of an asset.
 enum GenerationStatus: String, CaseIterable, Identifiable {
-    case notYetGenerated = "not-yet-generated"
+    case notYetGenerated  = "not-yet-generated"
     case previewGenerated = "preview-generated"
     case finalGenerated   = "final-generated"
 
@@ -12,7 +12,7 @@ enum GenerationStatus: String, CaseIterable, Identifiable {
 
     var label: String {
         switch self {
-        case .notYetGenerated: return "Not yet generated"
+        case .notYetGenerated:  return "Not yet generated"
         case .previewGenerated: return "Preview generated"
         case .finalGenerated:   return "Final generated"
         }
@@ -20,7 +20,7 @@ enum GenerationStatus: String, CaseIterable, Identifiable {
 
     var color: Color {
         switch self {
-        case .notYetGenerated: return .gray
+        case .notYetGenerated:  return .gray
         case .previewGenerated: return .orange
         case .finalGenerated:   return .green
         }
@@ -58,7 +58,7 @@ enum CastingItemType {
     case location
 }
 
-// MARK: - Casting item (used in Cast & Locations phase)
+// MARK: - Casting item
 
 struct CastingItem: Identifiable {
     let id: String
@@ -68,10 +68,11 @@ struct CastingItem: Identifiable {
     var status: GenerationStatus
     var libraryLevel: LibraryLevel
     var variantCount: Int
-    var approvedVariant: Int?       // 1-based index of approved preview variant
+    var approvedVariant: Int?
 }
 
-// MARK: - Library tree mock data
+// MARK: - Library tree structs
+// Property order must match memberwise init order used in MockData below.
 
 struct MockEpisode: Identifiable {
     let id: String
@@ -86,6 +87,8 @@ struct MockCustomer: Identifiable {
     var episodes: [MockEpisode]
 }
 
+/// NOTE: property order here defines the memberwise init order.
+/// customers comes before characters/locations so the init reads naturally.
 struct MockStudio: Identifiable {
     let id: String
     let name: String
@@ -109,7 +112,7 @@ struct MockItem: Identifiable {
 
 enum MockData {
 
-    // MARK: Casting phase items (flat list for center pane)
+    // MARK: Casting phase (flat lists for center pane)
 
     static let castingCharacters: [CastingItem] = [
         CastingItem(id: "ch-01", name: "Alex",   description: "The hero. Determined, mid-30s, athletic build.", type: .character, status: .finalGenerated,   libraryLevel: .customer, variantCount: 3, approvedVariant: 2),
@@ -118,22 +121,16 @@ enum MockData {
     ]
 
     static let castingLocations: [CastingItem] = [
-        CastingItem(id: "lo-01", name: "Rooftop",      description: "Urban rooftop, night skyline, neon reflections.", type: .location, status: .finalGenerated,   libraryLevel: .studio,   variantCount: 4, approvedVariant: 1),
-        CastingItem(id: "lo-02", name: "Office",       description: "Corporate open-plan office, daytime.",             type: .location, status: .notYetGenerated,  libraryLevel: .episode,  variantCount: 0, approvedVariant: nil),
-        CastingItem(id: "lo-03", name: "Underground",  description: "Subway station, flickering lights.",               type: .location, status: .previewGenerated, libraryLevel: .customer, variantCount: 2, approvedVariant: nil),
+        CastingItem(id: "lo-01", name: "Rooftop",     description: "Urban rooftop, night skyline, neon reflections.", type: .location, status: .finalGenerated,   libraryLevel: .studio,   variantCount: 4, approvedVariant: 1),
+        CastingItem(id: "lo-02", name: "Office",      description: "Corporate open-plan office, daytime.",             type: .location, status: .notYetGenerated,  libraryLevel: .episode,  variantCount: 0, approvedVariant: nil),
+        CastingItem(id: "lo-03", name: "Underground", description: "Subway station, flickering lights.",               type: .location, status: .previewGenerated, libraryLevel: .customer, variantCount: 2, approvedVariant: nil),
     ]
 
-    // MARK: Library tree
+    // MARK: Library tree (customers first — matches MockStudio memberwise init)
 
     static let libraryTree = MockStudio(
         id: "studio_main",
         name: "studio_main",
-        characters: [
-            CastingItem(id: "s-ch-01", name: "Narrator",      description: "Neutral, voice-over character.",         type: .character, status: .finalGenerated, libraryLevel: .studio, variantCount: 1, approvedVariant: 1),
-        ],
-        locations: [
-            CastingItem(id: "s-lo-01", name: "Black Void",    description: "Pure black infinite background.",        type: .location,  status: .finalGenerated, libraryLevel: .studio, variantCount: 1, approvedVariant: 1),
-        ],
         customers: [
             MockCustomer(
                 id: "customer_acme",
@@ -157,7 +154,7 @@ enum MockData {
                             CastingItem(id: "ac-e2-ch-01", name: "Jordan", description: "Villain returns.",         type: .character, status: .notYetGenerated,  libraryLevel: .episode, variantCount: 0, approvedVariant: nil),
                         ],
                         locations: [
-                            CastingItem(id: "ac-e2-lo-01", name: "Rooftop","Acme rooftop finale.",                  type: .location,  status: .previewGenerated, libraryLevel: .episode, variantCount: 2, approvedVariant: nil),
+                            CastingItem(id: "ac-e2-lo-01", name: "Rooftop", description: "Acme rooftop finale.",    type: .location,  status: .previewGenerated, libraryLevel: .episode, variantCount: 2, approvedVariant: nil),
                         ]
                     ),
                 ]
@@ -170,17 +167,17 @@ enum MockData {
                         id: "episode_nova_01",
                         name: "episode_nova_01",
                         characters: [
-                            CastingItem(id: "nv-e1-ch-01", name: "Lyra",  description: "Nova's protagonist.",       type: .character, status: .previewGenerated, libraryLevel: .episode, variantCount: 1, approvedVariant: nil),
+                            CastingItem(id: "nv-e1-ch-01", name: "Lyra", description: "Nova's protagonist.",        type: .character, status: .previewGenerated, libraryLevel: .episode, variantCount: 1, approvedVariant: nil),
                         ],
                         locations: [
-                            CastingItem(id: "nv-e1-lo-01", name: "Lab",   description: "High-tech research lab.",   type: .location,  status: .notYetGenerated,  libraryLevel: .episode, variantCount: 0, approvedVariant: nil),
+                            CastingItem(id: "nv-e1-lo-01", name: "Lab",  description: "High-tech research lab.",    type: .location,  status: .notYetGenerated,  libraryLevel: .episode, variantCount: 0, approvedVariant: nil),
                         ]
                     ),
                     MockEpisode(
                         id: "episode_nova_02",
                         name: "episode_nova_02",
                         characters: [
-                            CastingItem(id: "nv-e2-ch-01", name: "Rex",   description: "Nova security chief.",      type: .character, status: .notYetGenerated,  libraryLevel: .episode, variantCount: 0, approvedVariant: nil),
+                            CastingItem(id: "nv-e2-ch-01", name: "Rex",  description: "Nova security chief.",       type: .character, status: .notYetGenerated,  libraryLevel: .episode, variantCount: 0, approvedVariant: nil),
                         ],
                         locations: [
                             CastingItem(id: "nv-e2-lo-01", name: "Server Room", description: "Dim blue light, racks.", type: .location, status: .notYetGenerated, libraryLevel: .episode, variantCount: 0, approvedVariant: nil),
@@ -190,7 +187,7 @@ enum MockData {
                         id: "episode_nova_03",
                         name: "episode_nova_03",
                         characters: [
-                            CastingItem(id: "nv-e3-ch-01", name: "Echo",  description: "AI companion character.",   type: .character, status: .notYetGenerated,  libraryLevel: .episode, variantCount: 0, approvedVariant: nil),
+                            CastingItem(id: "nv-e3-ch-01", name: "Echo", description: "AI companion character.",    type: .character, status: .notYetGenerated,  libraryLevel: .episode, variantCount: 0, approvedVariant: nil),
                         ],
                         locations: [
                             CastingItem(id: "nv-e3-lo-01", name: "Void Station", description: "Derelict space station.", type: .location, status: .notYetGenerated, libraryLevel: .episode, variantCount: 0, approvedVariant: nil),
@@ -198,23 +195,29 @@ enum MockData {
                     ),
                 ]
             ),
+        ],
+        characters: [
+            CastingItem(id: "s-ch-01", name: "Narrator",   description: "Neutral, voice-over character.",  type: .character, status: .finalGenerated, libraryLevel: .studio, variantCount: 1, approvedVariant: 1),
+        ],
+        locations: [
+            CastingItem(id: "s-lo-01", name: "Black Void", description: "Pure black infinite background.", type: .location,  status: .finalGenerated, libraryLevel: .studio, variantCount: 1, approvedVariant: 1),
         ]
     )
 
-    // MARK: Other phases (unchanged)
+    // MARK: Other phases
 
     static func items(for section: AppSection?) -> [MockItem] {
         switch section {
         case .briefing:
             return [
-                MockItem(id: "b-01", name: "Studio Config",      icon: "gearshape",           color: .indigo, status: "Draft", variantCount: 1),
-                MockItem(id: "b-02", name: "Episode Config",      icon: "doc.badge.gearshape", color: .indigo, status: "Draft", variantCount: 1),
+                MockItem(id: "b-01", name: "Studio Config",     icon: "gearshape",           color: .indigo, status: "Draft", variantCount: 1),
+                MockItem(id: "b-02", name: "Episode Config",    icon: "doc.badge.gearshape", color: .indigo, status: "Draft", variantCount: 1),
             ]
         case .writing:
             return [
-                MockItem(id: "w-01", name: "Act 1 — Setup",       icon: "doc.text", color: .green, status: "Draft", variantCount: 1),
-                MockItem(id: "w-02", name: "Act 2 — Conflict",    icon: "doc.text", color: .green, status: "Draft", variantCount: 1),
-                MockItem(id: "w-03", name: "Act 3 — Resolution",  icon: "doc.text", color: .green, status: "Draft", variantCount: 1),
+                MockItem(id: "w-01", name: "Act 1 — Setup",      icon: "doc.text", color: .green, status: "Draft", variantCount: 1),
+                MockItem(id: "w-02", name: "Act 2 — Conflict",   icon: "doc.text", color: .green, status: "Draft", variantCount: 1),
+                MockItem(id: "w-03", name: "Act 3 — Resolution", icon: "doc.text", color: .green, status: "Draft", variantCount: 1),
             ]
         case .production:
             return [

--- a/DrawThingsStoryboard/Models/MockItem.swift
+++ b/DrawThingsStoryboard/Models/MockItem.swift
@@ -1,7 +1,101 @@
 import SwiftUI
 
-/// Lightweight placeholder item for UI prototyping.
-/// Replace with real domain models once filesystem layer is built.
+// MARK: - Enums
+
+/// Generation lifecycle of an asset.
+enum GenerationStatus: String, CaseIterable, Identifiable {
+    case notYetGenerated = "not-yet-generated"
+    case previewGenerated = "preview-generated"
+    case finalGenerated   = "final-generated"
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .notYetGenerated: return "Not yet generated"
+        case .previewGenerated: return "Preview generated"
+        case .finalGenerated:   return "Final generated"
+        }
+    }
+
+    var color: Color {
+        switch self {
+        case .notYetGenerated: return .gray
+        case .previewGenerated: return .orange
+        case .finalGenerated:   return .green
+        }
+    }
+}
+
+/// Where in the library hierarchy an asset lives.
+enum LibraryLevel: String, CaseIterable, Identifiable {
+    case studio   = "Studio"
+    case customer = "Customer"
+    case episode  = "Episode"
+
+    var id: String { rawValue }
+
+    var description: String {
+        switch self {
+        case .studio:   return "Shared across all customers"
+        case .customer: return "Shared within customer"
+        case .episode:  return "This episode only"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .studio:   return "building.columns"
+        case .customer: return "person.text.rectangle"
+        case .episode:  return "film"
+        }
+    }
+}
+
+/// Discriminates between the two casting sub-types.
+enum CastingItemType {
+    case character
+    case location
+}
+
+// MARK: - Casting item (used in Cast & Locations phase)
+
+struct CastingItem: Identifiable {
+    let id: String
+    var name: String
+    var description: String
+    var type: CastingItemType
+    var status: GenerationStatus
+    var libraryLevel: LibraryLevel
+    var variantCount: Int
+    var approvedVariant: Int?       // 1-based index of approved preview variant
+}
+
+// MARK: - Library tree mock data
+
+struct MockEpisode: Identifiable {
+    let id: String
+    let name: String
+    var characters: [CastingItem]
+    var locations: [CastingItem]
+}
+
+struct MockCustomer: Identifiable {
+    let id: String
+    let name: String
+    var episodes: [MockEpisode]
+}
+
+struct MockStudio: Identifiable {
+    let id: String
+    let name: String
+    var customers: [MockCustomer]
+    var characters: [CastingItem]   // studio-level shared characters
+    var locations: [CastingItem]    // studio-level shared locations
+}
+
+// MARK: - Generic browser item (non-casting phases)
+
 struct MockItem: Identifiable {
     let id: String
     let name: String
@@ -11,42 +105,125 @@ struct MockItem: Identifiable {
     let variantCount: Int
 }
 
-enum MockItems {
+// MARK: - Mock data factory
+
+enum MockData {
+
+    // MARK: Casting phase items (flat list for center pane)
+
+    static let castingCharacters: [CastingItem] = [
+        CastingItem(id: "ch-01", name: "Alex",   description: "The hero. Determined, mid-30s, athletic build.", type: .character, status: .finalGenerated,   libraryLevel: .customer, variantCount: 3, approvedVariant: 2),
+        CastingItem(id: "ch-02", name: "Sam",    description: "The sidekick. Cheerful, early 20s.",             type: .character, status: .previewGenerated, libraryLevel: .episode,  variantCount: 2, approvedVariant: nil),
+        CastingItem(id: "ch-03", name: "Jordan", description: "The antagonist. Cold, late 40s, sharp eyes.",    type: .character, status: .notYetGenerated,  libraryLevel: .episode,  variantCount: 0, approvedVariant: nil),
+    ]
+
+    static let castingLocations: [CastingItem] = [
+        CastingItem(id: "lo-01", name: "Rooftop",      description: "Urban rooftop, night skyline, neon reflections.", type: .location, status: .finalGenerated,   libraryLevel: .studio,   variantCount: 4, approvedVariant: 1),
+        CastingItem(id: "lo-02", name: "Office",       description: "Corporate open-plan office, daytime.",             type: .location, status: .notYetGenerated,  libraryLevel: .episode,  variantCount: 0, approvedVariant: nil),
+        CastingItem(id: "lo-03", name: "Underground",  description: "Subway station, flickering lights.",               type: .location, status: .previewGenerated, libraryLevel: .customer, variantCount: 2, approvedVariant: nil),
+    ]
+
+    // MARK: Library tree
+
+    static let libraryTree = MockStudio(
+        id: "studio_main",
+        name: "studio_main",
+        characters: [
+            CastingItem(id: "s-ch-01", name: "Narrator",      description: "Neutral, voice-over character.",         type: .character, status: .finalGenerated, libraryLevel: .studio, variantCount: 1, approvedVariant: 1),
+        ],
+        locations: [
+            CastingItem(id: "s-lo-01", name: "Black Void",    description: "Pure black infinite background.",        type: .location,  status: .finalGenerated, libraryLevel: .studio, variantCount: 1, approvedVariant: 1),
+        ],
+        customers: [
+            MockCustomer(
+                id: "customer_acme",
+                name: "customer_acme",
+                episodes: [
+                    MockEpisode(
+                        id: "episode_acme_01",
+                        name: "episode_acme_01",
+                        characters: [
+                            CastingItem(id: "ac-e1-ch-01", name: "Alex",   description: "Hero for Acme episode 1.", type: .character, status: .finalGenerated,   libraryLevel: .episode, variantCount: 3, approvedVariant: 2),
+                            CastingItem(id: "ac-e1-ch-02", name: "Sam",    description: "Sidekick.",                type: .character, status: .previewGenerated, libraryLevel: .episode, variantCount: 2, approvedVariant: nil),
+                        ],
+                        locations: [
+                            CastingItem(id: "ac-e1-lo-01", name: "Office", description: "Acme HQ daytime.",         type: .location,  status: .notYetGenerated,  libraryLevel: .episode, variantCount: 0, approvedVariant: nil),
+                        ]
+                    ),
+                    MockEpisode(
+                        id: "episode_acme_02",
+                        name: "episode_acme_02",
+                        characters: [
+                            CastingItem(id: "ac-e2-ch-01", name: "Jordan", description: "Villain returns.",         type: .character, status: .notYetGenerated,  libraryLevel: .episode, variantCount: 0, approvedVariant: nil),
+                        ],
+                        locations: [
+                            CastingItem(id: "ac-e2-lo-01", name: "Rooftop","Acme rooftop finale.",                  type: .location,  status: .previewGenerated, libraryLevel: .episode, variantCount: 2, approvedVariant: nil),
+                        ]
+                    ),
+                ]
+            ),
+            MockCustomer(
+                id: "customer_nova",
+                name: "customer_nova",
+                episodes: [
+                    MockEpisode(
+                        id: "episode_nova_01",
+                        name: "episode_nova_01",
+                        characters: [
+                            CastingItem(id: "nv-e1-ch-01", name: "Lyra",  description: "Nova's protagonist.",       type: .character, status: .previewGenerated, libraryLevel: .episode, variantCount: 1, approvedVariant: nil),
+                        ],
+                        locations: [
+                            CastingItem(id: "nv-e1-lo-01", name: "Lab",   description: "High-tech research lab.",   type: .location,  status: .notYetGenerated,  libraryLevel: .episode, variantCount: 0, approvedVariant: nil),
+                        ]
+                    ),
+                    MockEpisode(
+                        id: "episode_nova_02",
+                        name: "episode_nova_02",
+                        characters: [
+                            CastingItem(id: "nv-e2-ch-01", name: "Rex",   description: "Nova security chief.",      type: .character, status: .notYetGenerated,  libraryLevel: .episode, variantCount: 0, approvedVariant: nil),
+                        ],
+                        locations: [
+                            CastingItem(id: "nv-e2-lo-01", name: "Server Room", description: "Dim blue light, racks.", type: .location, status: .notYetGenerated, libraryLevel: .episode, variantCount: 0, approvedVariant: nil),
+                        ]
+                    ),
+                    MockEpisode(
+                        id: "episode_nova_03",
+                        name: "episode_nova_03",
+                        characters: [
+                            CastingItem(id: "nv-e3-ch-01", name: "Echo",  description: "AI companion character.",   type: .character, status: .notYetGenerated,  libraryLevel: .episode, variantCount: 0, approvedVariant: nil),
+                        ],
+                        locations: [
+                            CastingItem(id: "nv-e3-lo-01", name: "Void Station", description: "Derelict space station.", type: .location, status: .notYetGenerated, libraryLevel: .episode, variantCount: 0, approvedVariant: nil),
+                        ]
+                    ),
+                ]
+            ),
+        ]
+    )
+
+    // MARK: Other phases (unchanged)
 
     static func items(for section: AppSection?) -> [MockItem] {
         switch section {
         case .briefing:
             return [
-                MockItem(id: "b-01", name: "Studio Config",      icon: "gearshape",          color: .indigo,  status: "Draft",    variantCount: 1),
-                MockItem(id: "b-02", name: "Episode Config",     icon: "doc.badge.gearshape", color: .indigo,  status: "Draft",    variantCount: 1),
-            ]
-        case .casting:
-            return [
-                MockItem(id: "c-01", name: "Alex — Hero",        icon: "person.fill",         color: .blue,    status: "Approved", variantCount: 3),
-                MockItem(id: "c-02", name: "Sam — Sidekick",     icon: "person.fill",         color: .cyan,    status: "Draft",    variantCount: 2),
-                MockItem(id: "c-03", name: "Jordan — Villain",   icon: "person.fill",         color: .red,     status: "Draft",    variantCount: 1),
-                MockItem(id: "c-04", name: "Rooftop — Night",    icon: "building.2",          color: .purple,  status: "Approved", variantCount: 4),
-                MockItem(id: "c-05", name: "Office — Day",       icon: "building.2",          color: .orange,  status: "Draft",    variantCount: 2),
+                MockItem(id: "b-01", name: "Studio Config",      icon: "gearshape",           color: .indigo, status: "Draft", variantCount: 1),
+                MockItem(id: "b-02", name: "Episode Config",      icon: "doc.badge.gearshape", color: .indigo, status: "Draft", variantCount: 1),
             ]
         case .writing:
             return [
-                MockItem(id: "w-01", name: "Act 1 — Setup",      icon: "doc.text",            color: .green,   status: "Draft",    variantCount: 1),
-                MockItem(id: "w-02", name: "Act 2 — Conflict",   icon: "doc.text",            color: .green,   status: "Draft",    variantCount: 1),
-                MockItem(id: "w-03", name: "Act 3 — Resolution", icon: "doc.text",            color: .green,   status: "Draft",    variantCount: 1),
+                MockItem(id: "w-01", name: "Act 1 — Setup",       icon: "doc.text", color: .green, status: "Draft", variantCount: 1),
+                MockItem(id: "w-02", name: "Act 2 — Conflict",    icon: "doc.text", color: .green, status: "Draft", variantCount: 1),
+                MockItem(id: "w-03", name: "Act 3 — Resolution",  icon: "doc.text", color: .green, status: "Draft", variantCount: 1),
             ]
         case .production:
             return [
-                MockItem(id: "p-01", name: "Seq 01 — Sc 01",     icon: "photo",               color: .yellow,  status: "Draft",    variantCount: 2),
-                MockItem(id: "p-02", name: "Seq 01 — Sc 02",     icon: "photo",               color: .yellow,  status: "Approved", variantCount: 1),
-                MockItem(id: "p-03", name: "Seq 01 — Sc 03",     icon: "photo",               color: .yellow,  status: "Draft",    variantCount: 3),
-                MockItem(id: "p-04", name: "Seq 02 — Sc 01",     icon: "photo",               color: .orange,  status: "Draft",    variantCount: 1),
+                MockItem(id: "p-01", name: "Seq 01 — Sc 01", icon: "photo", color: .yellow, status: "Draft",    variantCount: 2),
+                MockItem(id: "p-02", name: "Seq 01 — Sc 02", icon: "photo", color: .yellow, status: "Approved", variantCount: 1),
+                MockItem(id: "p-03", name: "Seq 01 — Sc 03", icon: "photo", color: .yellow, status: "Draft",    variantCount: 3),
+                MockItem(id: "p-04", name: "Seq 02 — Sc 01", icon: "photo", color: .orange, status: "Draft",    variantCount: 1),
             ]
-        case .library:
-            return [
-                MockItem(id: "l-01", name: "studio_main",        icon: "building.columns",    color: .teal,    status: "Active",   variantCount: 12),
-                MockItem(id: "l-02", name: "customer_acme",      icon: "person.text.rectangle",color: .teal,   status: "Active",   variantCount: 6),
-            ]
-        case .none:
+        default:
             return []
         }
     }

--- a/README.md
+++ b/README.md
@@ -1,0 +1,54 @@
+# DrawThingsStoryboard
+
+A native macOS SwiftUI app for creating AI-generated storyboards using the [Draw Things](https://drawthings.ai) HTTP API.
+
+## Overview
+
+DrawThingsStoryboard follows a film production metaphor to help you build visual stories:
+
+| Phase | Description |
+|-------|-------------|
+| **Briefing** | General project configuration |
+| **Casting** | Define characters and locations |
+| **Writing** | Script and scene structure |
+| **Production** | Generate and assemble panels |
+
+Assets are organized in a portable **Library** hierarchy: Studio → Customer → Episode.
+
+## Requirements
+
+- macOS 14.0+
+- [Draw Things](https://drawthings.ai) running locally with HTTP API enabled (default: `localhost:7888`)
+- Xcode 15+
+
+## Getting Started
+
+```bash
+git clone https://github.com/SuperEugen/DrawThingsStoryboard.git
+cd DrawThingsStoryboard
+open DrawThingsStoryboard.xcodeproj
+```
+
+Build and run in Xcode. Make sure Draw Things is running before using the Production phase.
+
+## Project Structure
+
+```
+DrawThingsStoryboard/
+├── App/                  # Entry point, navigation, routing
+├── Features/
+│   ├── ItemBrowser/      # Center + right pane views
+│   ├── Library/          # Library hierarchy navigator
+│   ├── ImageGeneration/  # Draw Things API integration
+│   └── Settings/         # App settings
+├── Models/               # Data models and mock data
+└── Services/             # HTTP client and protocols
+```
+
+## Contributing
+
+See [CONTRIBUTORS.md](CONTRIBUTORS.md).
+
+## License
+
+MIT


### PR DESCRIPTION
## What this PR adds

This branch builds the foundational UI for DrawThingsStoryboard — a clickable, navigable prototype with mock data throughout. No real filesystem access yet; that comes in a follow-up.

### Navigation & layout
- `NavigationSplitView` with three panes: sidebar / item browser / detail
- Left pane: phase navigation (Briefing, Casting, Writing, Production) + Library section
- `AppSection` enum replaces the placeholder `imageGeneration` case

### Cast & Locations phase (center + right pane)
- Two independent sub-sections: **Cast** and **Locations**, each with + / − buttons
- Tapping a tile selects it and populates the right pane
- Right pane shows:
  - Read-only **type** badge (Character / Location)
  - Selectable **generation status** (not yet generated / preview generated / final generated)
  - Selectable **library level** (Studio / Customer / Episode) with descriptions
  - Editable **name** and **description** fields
  - **Queue for Production** button (disabled until name is filled)

### Library navigator
- Sidebar within Library: Studio → Customer → Episode drill-down
- Clicking Studio shows all assets aggregated; Customer narrows to that customer; Episode shows only that episode
- Asset tiles carry **ST / CU / EP** level badges and status dots
- Right pane reuses `CastingItemDetailView`

### Mock data
- `CastingItem`, `GenerationStatus`, `LibraryLevel` models
- Two customers: **customer_acme** (2 episodes) and **customer_nova** (3 episodes)
- Studio-level shared assets (Narrator, Black Void)

### Docs
- `README.md` with project overview, requirements, structure
- `CONTRIBUTORS.md` crediting author and AI assistance

## Notes
- `ImageGenerationViewModel` has one pre-existing `@MainActor` warning — unrelated to this PR
- All mock data lives in `MockItem.swift`; real filesystem layer is the next milestone
